### PR TITLE
Fix explosion sprite FPS.

### DIFF
--- a/data/images/objects/explosion/explosion.sprite
+++ b/data/images/objects/explosion/explosion.sprite
@@ -1,7 +1,7 @@
 (supertux-sprite
   (action
     (name "default")
-    (fps 15.0)
+    (fps 8.0)
     (hitbox 36 36 48 48)
     (images 
       "explosion-0.png"


### PR DESCRIPTION
A small pull request fixing explosion sprite framerate. Now it should explode for approx 1 second.